### PR TITLE
Save and load options using cookies

### DIFF
--- a/index.html
+++ b/index.html
@@ -111,7 +111,7 @@
         <h6 class="text-muted">A website to generate a meaning for the abbreviation selected below, originally for use in online storytelling.</h6>
         <br><br>
         <div class="input-group mb-1">
-            <select class="form-control" id="first-select">
+            <select class="form-control" id="first-select" onchange="saveOptionAsCookie(this)">
                 <option value="a_first_words">A</option>
                 <option value="b_first_words">B</option>
                 <option value="c_first_words">C</option>
@@ -126,7 +126,7 @@
                 <option value="s_first_words">S</option>
                 <option value="t_first_words">T</option>
             </select>
-            <select class="form-control" id="second-select">
+            <select class="form-control" id="second-select"  onchange="saveOptionAsCookie(this)">
                 <option value="a_second_words">A</option>
                 <option value="b_second_words">B</option>
                 <option value="c_second_words">C</option>
@@ -212,6 +212,45 @@
             }
         });
     </script>
+
+    <!-- Script to save options as cookies -->
+    <script>
+            function setCookie(cname, cvalue, exdays) {
+                var d = new Date();
+                d.setTime(d.getTime() + (exdays*24*60*60*1000));
+                var expires = "expires="+ d.toUTCString();
+                document.cookie = cname + "=" + cvalue + ";" + expires + ";path=/";
+            }
+    
+            function getCookie(cname) {
+                var name = cname + "=";
+                var decodedCookie = decodeURIComponent(document.cookie);
+                var ca = decodedCookie.split(';');
+                for(var i = 0; i <ca.length; i++) {
+                    var c = ca[i];
+                    while (c.charAt(0) == ' ') {
+                    c = c.substring(1);
+                    }
+                    if (c.indexOf(name) == 0) {
+                    return c.substring(name.length, c.length);
+                    }
+                }
+                return "";
+            }
+    
+            function saveOptionAsCookie(el) {
+                setCookie(el.id, el.value, 90);
+            }
+            
+            function getOptionsFromCookies() {
+                var select_first = document.getElementById("first-select");
+                var select_second = document.getElementById("second-select");
+                select_first.value = getCookie("first-select");
+                select_second.value = getCookie("second-select");
+                run();
+            }
+            getOptionsFromCookies();
+        </script>
 </body>
 
 </html>


### PR DESCRIPTION
## Save and load options using cookies

 - Fixed #30 .
 - Added `onload` attributes to each of the `select` tags.
 - Added a script at the end of body which contains:
    - `setCookie` - function that takes name, value and number of days until the cookie expires and sets a cookie with those parameters.
    - `getCookie` - function which returns the cookie value given the name.
    - `saveOptionsAsCookie` - function to set a cookie with the element's id as name and element's value as value.
    - `getOptionsFromCookies` - function to get the saved options from the cookies and set them. It also calls the `run()` function to regenerate the mystery egg